### PR TITLE
Restore microdnf update step in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,10 @@ LABEL org.label-schema.vendor="Red Hat" \
       io.k8s.description="$IMAGE_DESCRIPTION" \
       io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
 
+RUN microdnf update &&\
+    microdnf install ca-certificates vi --nodocs &&\
+    microdnf clean all
+
 ENV BABEL_DISABLE_CACHE=1 \
     NODE_ENV=production \
     USER_UID=1001 \


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#11040

### Description of changes
- Restore microdnf update step in Dockerfile to always build with the latest security updates.

