### PR TITLE
Fix error with secret labels

### DIFF
--- a/src/v2/models/application.js
+++ b/src/v2/models/application.js
@@ -131,7 +131,7 @@ export default class AppModel {
           // open-cluster-management.io/cluster-server label will only contain hostname, limited to 63 chars
           || (app['app.destinationServer'] && s['s.label'].find((l) => l.startsWith('open-cluster-management.io/cluster-server=')
                 && app['app.destinationServer'].includes(labelValue(l)))));
-      const label = secret['s.label'].find((l) => l.startsWith('open-cluster-management.io/cluster-name='));
+      const label = secret && secret['s.label'].find((l) => l.startsWith('open-cluster-management.io/cluster-name='));
       if (label) {
         return labelValue(label);
       }


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#9034
### Description of changes
Fixes error in query for when there is no matching cluster secret
![image](https://user-images.githubusercontent.com/42188127/114724417-849bc680-9d09-11eb-94b4-3b78779b0c4f.png)


