### PR TITLE
Fix label name prefix for Argo cluster secrets

### DIFF
--- a/src/v2/mocks/search.js
+++ b/src/v2/mocks/search.js
@@ -127,8 +127,8 @@ const MOCK_QUERIES = {
       's._uid': 'local-cluster/29a848d6-3de8-11ea-9f0f-00000a100f99',
       's.label': [
         'argocd.argoproj.io/secret-type=cluster',
-        'open-cluster-management.io/cluster-server=kube.net',
-        'open-cluster-management.io/cluster-name=remote-cluster',
+        'apps.open-cluster-management.io/cluster-server=kube.net',
+        'apps.open-cluster-management.io/cluster-name=remote-cluster',
       ],
       's.cluster': 'local-cluster',
     },

--- a/src/v2/models/application.js
+++ b/src/v2/models/application.js
@@ -34,6 +34,8 @@ function getLocalRemoteClusterCounts(resourceUid, resourceType, data) {
 const SUB_NAME = 'sub.name';
 const SUB_NAMESPACE = 'sub.namespace';
 
+const ARGO_LABEL_PREFIX = 'apps.open-cluster-management.io/';
+
 function filterLocalSubscriptions(subs) {
   const localSuffix = '-local';
 
@@ -127,11 +129,11 @@ export default class AppModel {
       const clusterSecrets = await this.runQueryOnlyOnce('runArgoClusterSecretsQuery');
       const secret = clusterSecrets
         .filter((s) => s['s.cluster'] === app['app.cluster'])
-        .find((s) => (app['app.destinationName'] && s['s.label'].includes(`open-cluster-management.io/cluster-name=${app['app.destinationName']}`))
-          // open-cluster-management.io/cluster-server label will only contain hostname, limited to 63 chars
-          || (app['app.destinationServer'] && s['s.label'].find((l) => l.startsWith('open-cluster-management.io/cluster-server=')
+        .find((s) => (app['app.destinationName'] && s['s.label'].includes(`${ARGO_LABEL_PREFIX}cluster-name=${app['app.destinationName']}`))
+          // cluster-server label will only contain hostname, limited to 63 chars
+          || (app['app.destinationServer'] && s['s.label'].find((l) => l.startsWith(`${ARGO_LABEL_PREFIX}cluster-server=`)
                 && app['app.destinationServer'].includes(labelValue(l)))));
-      const label = secret && secret['s.label'].find((l) => l.startsWith('open-cluster-management.io/cluster-name='));
+      const label = secret && secret['s.label'].find((l) => l.startsWith(`${ARGO_LABEL_PREFIX}cluster-name=`));
       if (label) {
         return labelValue(label);
       }


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#9034
### Description of changes
- Label prefix for Argo cluster secrets changed from initial design

