### PR TITLE
removed possibility for undefined in Message's id value

### DIFF
--- a/src/v2/schema/message.js
+++ b/src/v2/schema/message.js
@@ -3,7 +3,7 @@ import { gql } from 'apollo-server-express';
 export const typeDef = gql`
   type Message {
     # Unique identifier for each message.
-    id: String
+    id: String!
     # Describes the type of message. Expected values are: information, warning, error.
     kind: String
     # Message text.


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#12024

### Description of changes
- Changed value type from `String` to `String!` of Message query to prevent undefined value.

