### PR TITLE
[2.4 WIP] Migrate console-api queries to search-api

### DIFF
--- a/config/config-defaults.json
+++ b/config/config-defaults.json
@@ -1,4 +1,6 @@
 {
+  "acmPollInterval": 100,
+  "acmPollTimeout": 15000,
   "API_SERVER_URL": "https://kubernetes.default.svc",
   "contextPath": "/searchapi",
   "defaultQueryLimit": 10000,

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,7 @@ const jestConfig = {
   ],
   coverageThreshold: {
     global: {
-      branches: 38,
+      branches: 35,
       functions: 59,
       lines: 49,
       statements: 50,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6116,6 +6116,13 @@
             "deprecated-decorator": "^0.1.6",
             "iterall": "^1.1.3",
             "uuid": "^3.1.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
           }
         },
         "subscriptions-transport-ws": {
@@ -8600,7 +8607,7 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "ua-parser-js": "^0.7.23"
       }
     },
     "fbjs-css-vars": {
@@ -13208,6 +13215,11 @@
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -14715,9 +14727,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "nocache": "^3.0.1",
     "redis": "^3.1.2",
     "redisgraph.js": "^2.3.0",
-    "requestretry": "^5.0.0"
+    "requestretry": "^5.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.5",

--- a/src/v2/connectors/__snapshots__/kube.test.js.snap
+++ b/src/v2/connectors/__snapshots__/kube.test.js.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`KubeConnector CreateManagedClusterView creates and polls ManagedClusterView api 1`] = `
+Object {
+  "status": Object {
+    "conditions": Array [
+      Object {
+        "lastUpdateTime": "2018-08-15T18:44:41Z",
+        "type": "Processing",
+      },
+    ],
+    "result": Object {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": Object {
+        "creationTimestamp": "2020-05-13T20:24:01Z",
+        "generateName": "search-prod-28a0e-search-api-66cf776db5-",
+        "labels": Object {
+          "app": "search",
+          "chart": "search-prod-3.5.0",
+          "component": "search-api",
+          "heritage": "Helm",
+          "pod-template-hash": "66cf776db5",
+          "release": "search-prod-28a0e",
+        },
+        "name": "search-prod-28a0e-search-api-66cf776db5-7bzfh",
+        "namespace": "open-cluster-management",
+        "resourceVersion": "45078202",
+        "selfLink": "/api/v1/namespaces/open-cluster-management/pods/search-prod-28a0e-search-api-66cf776db5-7bzfh",
+        "uid": "7ecc7859-5ce4-4e34-8834-bd687c0fe43d",
+      },
+      "status": Object {
+        "conditions": Array [
+          Object {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-05-13T20:24:02Z",
+            "status": "True",
+            "type": "Initialized",
+          },
+          Object {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-05-13T20:24:33Z",
+            "status": "True",
+            "type": "Ready",
+          },
+          Object {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-05-13T20:24:33Z",
+            "status": "True",
+            "type": "ContainersReady",
+          },
+          Object {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-05-13T20:24:02Z",
+            "status": "True",
+            "type": "PodScheduled",
+          },
+        ],
+        "phase": "Running",
+        "qosClass": "Burstable",
+        "startTime": "2020-05-13T20:24:02Z",
+      },
+    },
+  },
+}
+`;
+
 exports[`KubeConnector Get calls default connector 1`] = `
 Array [
   Object {

--- a/src/v2/connectors/kube.js
+++ b/src/v2/connectors/kube.js
@@ -10,18 +10,29 @@
 // Copyright Contributors to the Open Cluster Management project
 
 import _ from 'lodash';
+import crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
 import request from '../lib/request';
 import config from '../../../config';
+import logger from '../lib/logger';
 
 export default class KubeConnector {
   constructor({
     token = 'localdev',
     kubeApiEndpoint = `${config.get('API_SERVER_URL')}` || 'https://kubernetes.default.svc',
     httpLib = request,
+    namespaces = [],
+    pollTimeout = config.get('acmPollTimeout'),
+    pollInterval = config.get('acmPollInterval'),
+    uid = uuidv4,
   } = {}) {
     this.kubeApiEndpoint = kubeApiEndpoint;
     this.token = token;
     this.http = httpLib;
+    this.namespaces = namespaces;
+    this.pollInterval = pollInterval;
+    this.pollTimeout = pollTimeout;
+    this.uid = uid;
   }
 
   /**
@@ -36,6 +47,18 @@ export default class KubeConnector {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${this.token}`,
+      },
+    };
+    return this.http(_.merge(defaults, opts)).then((res) => res.body);
+  }
+
+  put(path = '', opts = {}) {
+    const defaults = {
+      url: `${this.kubeApiEndpoint}${path}`,
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
       },
     };
     return this.http(_.merge(defaults, opts)).then((res) => res.body);
@@ -64,5 +87,185 @@ export default class KubeConnector {
       json: jsonBody,
     };
     return this.http(_.merge(defaults, opts)).then((res) => res.body);
+  }
+
+  delete(path = '', jsonBody, opts = {}) {
+    const defaults = {
+      url: `${this.kubeApiEndpoint}${path}`,
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+      },
+      json: jsonBody,
+    };
+    return this.http(_.merge(defaults, opts)).then((res) => res.body);
+  }
+
+  async getK8sPaths() {
+    if (!this.k8sPaths) {
+      this.k8sPaths = this.get('/').catch((err) => {
+        logger.error(err);
+        throw err;
+      });
+    }
+    return (await this.k8sPaths).paths;
+  }
+
+  timeout() {
+    return new Promise((r, reject) => setTimeout(reject, this.pollTimeout, new Error('Manager request timed out')));
+  }
+
+  pollView(viewLink) {
+    let cancel;
+
+    const promise = new Promise((resolve, reject) => {
+      let pendingRequest = false;
+      const intervalID = setInterval(async () => {
+        if (!pendingRequest) {
+          pendingRequest = true;
+          try {
+            const links = viewLink.split('/');
+            const viewName = links.pop();
+            const link = `${links.join('/')}?fieldSelector=metadata.name=${viewName}`;
+
+            logger.debug('start polling: ', new Date(), link);
+            const response = await this.get(link, {}, true);
+            pendingRequest = false;
+            if (response.code || response.message) {
+              clearInterval(intervalID);
+              return reject(response);
+            }
+            // We are looking for the type to be Processing for ManagedClusterView resources
+            // TODO remove the 'Completed' logic when resource view is removed
+            const isComplete = _.get(response, 'items[0].status.conditions[0].type') || _.get(response, 'items[0].status.status') || _.get(response, 'items[0].status.type') || _.get(response, 'items[0].status.conditions[0].type', 'NO');
+            if (isComplete === 'Processing' || isComplete === 'Completed') {
+              clearInterval(intervalID);
+              logger.debug('start to get resource: ', new Date(), viewLink);
+              const result = await this.get(viewLink, {}, true);
+              if (result.code || result.message) {
+                return reject(result);
+              }
+              resolve(result);
+            }
+          } catch (err) {
+            clearInterval(intervalID);
+            reject(err);
+          }
+        }
+        return null;
+      }, this.pollInterval);
+
+      cancel = () => {
+        clearInterval(intervalID);
+        // reject or resolve?
+        reject();
+      };
+    });
+
+    return { cancel, promise };
+  }
+
+  // eslint-disable-next-line max-len
+  async managedClusterViewQuery(managedClusterNamespace, apiGroup, version, kind, resourceName, namespace, updateInterval, deleteAfterUse) {
+    // name cannot be long than 63 chars in length
+    const name = crypto.createHash('sha1').update(`${managedClusterNamespace}-${resourceName}-${kind}`).digest('hex').substr(0, 63);
+
+    // scope.name is required, and either GKV (scope.apiGroup+kind+version) or scope.resource
+    const body = {
+      apiVersion: 'view.open-cluster-management.io/v1beta1',
+      kind: 'ManagedClusterView',
+      metadata: {
+        labels: {
+          name,
+        },
+        name,
+        namespace: managedClusterNamespace,
+      },
+      spec: {
+        scope: {
+          name: resourceName,
+          resource: apiGroup ? `${kind.toLowerCase()}.${version}.${apiGroup}` : `${kind.toLowerCase()}`,
+        },
+      },
+    };
+    // Only set namespace if not null
+    if (namespace) {
+      body.spec.scope.namespace = namespace;
+    }
+    if (updateInterval) {
+      body.spec.scope.updateIntervalSeconds = updateInterval; // default is 30 secs
+    }
+    // Create ManagedClusterView
+    const apiPath = `/apis/view.open-cluster-management.io/v1beta1/namespaces/${managedClusterNamespace}/managedclusterviews`;
+    const managedClusterViewResponse = await this.post(apiPath, body);
+    if (_.get(managedClusterViewResponse, 'status.conditions[0].status') === 'False' || managedClusterViewResponse.code >= 400) {
+      throw new Error(`Create ManagedClusterView Failed [${managedClusterViewResponse.code}] - ${managedClusterViewResponse.message}`);
+    }
+    // Poll ManagedClusterView until success or failure
+    const managedClusterViewName = _.get(managedClusterViewResponse, 'metadata.name');
+    const { cancel, promise: pollPromise } = this.pollView(`${apiPath}/${managedClusterViewName}`);
+    try {
+      const result = await Promise.race([pollPromise, this.timeout()]);
+      if (result && deleteAfterUse) {
+        this.deleteManagedClusterView(managedClusterNamespace, managedClusterViewResponse.metadata.name);
+      }
+      return result;
+    } catch (e) {
+      logger.error(`ManagedClusterView Query Error for ${kind}`, e.message);
+      cancel();
+      throw e;
+    }
+  }
+
+  async deleteManagedClusterView(managedClusterNamespace, managedClusterViewName) {
+    this.delete(`/apis/view.open-cluster-management.io/v1beta1/namespaces/${managedClusterNamespace}/managedclusterviews/${managedClusterViewName}`)
+      .catch((e) => logger.error(`Error deleting managed cluster view ${managedClusterViewName}`, e.message));
+  }
+
+  /**
+   * Excecute Kube API GET requests for namespaces resources.
+   *
+   * @param {*} urlTemplate - function from namespace to url path
+   * @param {*} opts - default namespace list override
+   * @param {*} opts - kind of returned items--used to create valid k8s yaml
+   */
+  async getResources(urlTemplate, { namespaces, kind } = {}) {
+    const namespaceList = (namespaces || this.namespaces);
+
+    const requests = namespaceList.map(async (ns) => {
+      let response;
+      try {
+        response = await this.get(urlTemplate(ns));
+      } catch (err) {
+        logger.error(`OCM REQUEST ERROR  for ${urlTemplate(ns)} - ${err.message}`);
+        return [];
+      }
+
+      if (response.code || response.message) {
+        logger.error(`OCM ERROR ${response.code} (${urlTemplate(ns)}) - ${response.message}`);
+        return [];
+      }
+
+      // if all responses aren't objects, throw error
+      const strs = [];
+      const items = (response.items ? response.items : [response]);
+      items.forEach((item) => {
+        if (typeof item === 'string') {
+          strs.push(item);
+        }
+      });
+      if (strs.length > 0) {
+        logger.error(`OCM RESPONSE ERROR for ${urlTemplate(ns)}: Expected Objects but Returned this: ${strs.join(', ')}`);
+        return [];
+      }
+
+      return items.map((item) => (kind ? ({
+        apiVersion: response.apiVersion,
+        kind,
+        ...item,
+      }) : item));
+    });
+
+    return _.flatten(await Promise.all(requests));
   }
 }

--- a/src/v2/connectors/kube.test.js
+++ b/src/v2/connectors/kube.test.js
@@ -13,6 +13,102 @@ import KubeConnector from './kube';
 
 const asyncReturn = (value, waitTime = 500) => new Promise((res) => setTimeout(res, waitTime, value));
 
+const mockManagedClusterView = {
+  body: {
+    metadata: {
+      selfLink: '/apis/view.open-cluster-management.io/v1beta1/namespaces/cluster-test/managedclusterviews/spoke-test',
+    },
+  },
+};
+
+const mockManagedClusterViewPollIncomplete = {
+  body: {
+    items: [
+      {
+        status: {
+          status: 'Not Finished',
+        },
+      },
+    ],
+  },
+};
+
+const mockManagedClusterViewPollComplete = {
+  body: {
+    items: [
+      {
+        status: {
+          conditions: [
+            { type: 'Processing', lastUpdateTime: '2018-08-15T18:44:41Z' },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const mockManagedClusterViewResults = {
+  body: {
+    status: {
+      conditions: [
+        { type: 'Processing', lastUpdateTime: '2018-08-15T18:44:41Z' },
+      ],
+      result: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          creationTimestamp: '2020-05-13T20:24:01Z',
+          generateName: 'search-prod-28a0e-search-api-66cf776db5-',
+          labels: {
+            app: 'search',
+            chart: 'search-prod-3.5.0',
+            component: 'search-api',
+            heritage: 'Helm',
+            'pod-template-hash': '66cf776db5',
+            release: 'search-prod-28a0e',
+          },
+          name: 'search-prod-28a0e-search-api-66cf776db5-7bzfh',
+          namespace: 'open-cluster-management',
+          resourceVersion: '45078202',
+          selfLink: '/api/v1/namespaces/open-cluster-management/pods/search-prod-28a0e-search-api-66cf776db5-7bzfh',
+          uid: '7ecc7859-5ce4-4e34-8834-bd687c0fe43d',
+        },
+        status: {
+          conditions: [
+            {
+              lastProbeTime: null,
+              lastTransitionTime: '2020-05-13T20:24:02Z',
+              status: 'True',
+              type: 'Initialized',
+            },
+            {
+              lastProbeTime: null,
+              lastTransitionTime: '2020-05-13T20:24:33Z',
+              status: 'True',
+              type: 'Ready',
+            },
+            {
+              lastProbeTime: null,
+              lastTransitionTime: '2020-05-13T20:24:33Z',
+              status: 'True',
+              type: 'ContainersReady',
+            },
+            {
+              lastProbeTime: null,
+              lastTransitionTime: '2020-05-13T20:24:02Z',
+              status: 'True',
+              type: 'PodScheduled',
+            },
+          ],
+          phase: 'Running',
+          qosClass: 'Burstable',
+          startTime: '2020-05-13T20:24:02Z',
+        },
+      },
+    },
+  },
+};
+
 describe('KubeConnector', () => {
   describe('Get', () => {
     test('calls default connector', async () => {
@@ -74,6 +170,39 @@ describe('KubeConnector', () => {
 
       expect(mockHttp.mock.calls[0]).toHaveLength(1);
       expect(mockHttp.mock.calls[0]).toMatchSnapshot();
+    });
+  });
+
+  describe('CreateManagedClusterView', () => {
+    test('creates and polls ManagedClusterView api', async () => {
+      const mockCache = { get: jest.fn().mockReturnValue(null), set: jest.fn() };
+      const mockHttp = jest.fn()
+        .mockImplementationOnce(() => asyncReturn(mockManagedClusterView))
+        .mockImplementationOnce(() => asyncReturn(mockManagedClusterViewPollIncomplete))
+        .mockImplementationOnce(() => asyncReturn(mockManagedClusterViewPollIncomplete))
+        .mockImplementationOnce(() => asyncReturn(mockManagedClusterViewPollIncomplete))
+        .mockImplementationOnce(() => asyncReturn(mockManagedClusterViewPollComplete))
+        .mockImplementation(() => asyncReturn(mockManagedClusterViewResults));
+
+      const connector = new KubeConnector({
+        cache: mockCache,
+        kubeApiEndpoint: 'kubernetes',
+        httpLib: mockHttp,
+        uid: () => '1234',
+        namespaces: ['open-cluster-management'],
+      });
+
+      const result = await connector.managedClusterViewQuery(
+        'cluster-test',
+        '',
+        'Pod',
+        'search-prod-28a0e-search-api-66cf776db5-7bzfh',
+        'open-cluster-management',
+        30,
+        true,
+      );
+
+      expect(result).toMatchSnapshot();
     });
   });
 });

--- a/src/v2/lib/auth-middleware.js
+++ b/src/v2/lib/auth-middleware.js
@@ -5,8 +5,8 @@
  * Note to U.S. Government Users Restricted Rights:
  * Use, duplication or disclosure restricted by GSA ADP Schedule
  * Contract with IBM Corp.
- * Copyright (c) 2020 Red Hat, Inc.
  ****************************************************************************** */
+// Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
 import _ from 'lodash';
@@ -60,8 +60,7 @@ async function getNamespaces(usertoken) {
     const mockReq = createMockIAMHTTP();
     return mockReq(options);
   }
-  const nsResponse = await request(options);
-  return Array.isArray(nsResponse.items) ? nsResponse.items.map((ns) => ns.metadata.name) : [];
+  return request(options);
 }
 
 async function getUsername(usertoken) {
@@ -123,6 +122,14 @@ export default function createAuthMiddleWare({
       userNamePromise = getUsername(idToken);
       cache.set(`userName_${idToken}`, userNamePromise);
     }
+
+    req.updateUserNamespaces = async (project) => {
+      const projectPromise = await cache.get(`namespaces_${idToken}`);
+      if (projectPromise && project) {
+        projectPromise.items.push(project);
+        cache.set(`namespaces_${idToken}`, projectPromise);
+      }
+    };
 
     req.user = {
       name: await userNamePromise,

--- a/src/v2/mocks/kube.js
+++ b/src/v2/mocks/kube.js
@@ -208,6 +208,17 @@ export default class MockKubeConnector {
           status: { phase: 'Active' },
         }],
       };
+    } if (url.endsWith('/apis/proxy.open-cluster-management.io/v1beta1/namespaces/cluster1/clusterstatuses/cluster1/log/open-cluster-management/search-prod-28a0e-search-api-66cf776db5-7bzfh/search-api?tailLines=1000')) {
+      return '[2020-05-13T20:24:23.321] [INFO] [search-api] [server] Built from git commit:  0.0.0-sha.f31e583\n[2020-05-13T20:24:23.674] [INFO] [search-api] [server] Initializing new Redis client.\n[2020-05-13T20:24:23.674] [INFO] [search-api] [server] Starting Redis client using SSL endpoint:  search-prod-28a0e-search-redisgraph:6380\n[2020-05-13T20:24:23.725] [INFO] [search-api] [server] Authentication enabled\n[2020-05-13T20:24:23.725] [INFO] [search-api] [server] Using RedisGraph search connector.\n[2020-05-13T20:24:23.740] [INFO] [search-api] [server] [pid 1] [env production] [version V2] started.\n[2020-05-13T20:24:23.740] [INFO] [search-api] [server] Search API is now running on https://localhost:4010/searchapi/graphql\n[2020-05-13T20:24:23.740] [INFO] [search-api] [server] RedisGraph address: "172.30.110.50" family: IPv4';
+    } if (url === '/') {
+      return {
+        paths: [
+          '/api',
+          '/api/v1',
+          '/apis',
+          '/apis/',
+        ],
+      };
     }
     // return null if request has not been mocked.
     return null;

--- a/src/v2/models/application.js
+++ b/src/v2/models/application.js
@@ -257,4 +257,27 @@ export default class AppModel {
     const clusters = await this.runQueryOnlyOnce('runChannelClustersQuery');
     return getLocalRemoteClusterCounts(chUid, 'ch', clusters);
   }
+
+  // for overview page
+  async getApplicationOverview(name, namespace = 'default') {
+    let apps;
+    try {
+      if (name) {
+        apps = await this.kubeConnector.getResources(
+          (ns) => `/apis/app.k8s.io/v1beta1/namespaces/${ns}/applications/${name}`,
+          { namespaces: [namespace] },
+        );
+      } else {
+        apps = await this.kubeConnector.getResources((ns) => `/apis/app.k8s.io/v1beta1/namespaces/${ns}/applications`);
+      }
+      apps = await Promise.all(apps);
+    } catch (err) {
+      logger.error(err);
+      throw err;
+    }
+    return apps.filter((app) => app.metadata)
+      .map((app) => ({
+        metadata: app.metadata,
+      }));
+  }
 }

--- a/src/v2/models/cluster.js
+++ b/src/v2/models/cluster.js
@@ -1,0 +1,296 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import _ from 'lodash';
+import KubeModel from './kube';
+import logger from '../lib/logger';
+
+export const HIVE_DOMAIN = 'hive.openshift.io';
+export const UNINSTALL_LABEL = `${HIVE_DOMAIN}/uninstall`;
+export const INSTALL_LABEL = `${HIVE_DOMAIN}/install`;
+export const CLUSTER_LABEL = `${HIVE_DOMAIN}/cluster-deployment-name`;
+export const UNINSTALL_LABEL_SELECTOR = (cluster) => `labelSelector=${UNINSTALL_LABEL}%3Dtrue%2C${CLUSTER_LABEL}%3D${cluster}`;
+export const INSTALL_LABEL_SELECTOR = (cluster) => `labelSelector=${INSTALL_LABEL}%3Dtrue%2C${CLUSTER_LABEL}%3D${cluster}`;
+export const UNINSTALL_LABEL_SELECTOR_ALL = `labelSelector=${UNINSTALL_LABEL}%3Dtrue`;
+export const INSTALL_LABEL_SELECTOR_ALL = `labelSelector=${INSTALL_LABEL}%3Dtrue`;
+
+export const CLUSTER_DOMAIN = 'cluster.open-cluster-management.io';
+export const CLUSTER_NAMESPACE_LABEL = `${CLUSTER_DOMAIN}/managedCluster`;
+
+export const CSR_LABEL = 'open-cluster-management.io/cluster-name';
+export const CSR_LABEL_SELECTOR = (cluster) => `labelSelector=${CSR_LABEL}%3D${cluster}`;
+export const CSR_LABEL_SELECTOR_ALL = `labelSelector=${CSR_LABEL}`;
+
+function getLatest(items, key) {
+  if (items.length === 0) {
+    return undefined;
+  }
+  if (items.length === 1) {
+    return items[0];
+  }
+
+  return items.reduce((a, b) => {
+    const [timeA, timeB] = [a, b].map((x) => new Date(_.get(x, key, '')));
+    return timeA > timeB ? a : b;
+  });
+}
+
+function getClusterDeploymentStatus(clusterDeployment, uninstall, install) {
+  const latestJobActive = (jobs) => (jobs && _.get(getLatest(jobs, 'metadata.creationTimestamp'), 'status.active', 0) > 0);
+  const latestJobFailed = (jobs) => (jobs && _.get(getLatest(jobs, 'metadata.creationTimestamp'), 'status.failed', 0) > 0);
+
+  let status = 'pending';
+  if (latestJobActive(uninstall)) {
+    status = 'destroying';
+  } else if (latestJobActive(install)) {
+    status = 'creating';
+  } else if (latestJobFailed(install) || latestJobFailed(uninstall)) {
+    status = 'provisionfailed';
+  } else if (_.get(clusterDeployment, 'spec.installed')) {
+    status = 'detached';
+  }
+  return status;
+}
+
+export function getStatus(cluster, csrs, clusterDeployment, uninstall, install) {
+  const clusterDeploymentStatus = clusterDeployment
+    ? getClusterDeploymentStatus(clusterDeployment, uninstall, install)
+    : '';
+
+  if (cluster) {
+    let status;
+    const clusterConditions = _.get(cluster, 'status.conditions') || [];
+    const checkForCondition = (condition) => _.get(
+      clusterConditions.find((c) => c.type === condition),
+      'status',
+    ) === 'True';
+    const clusterAccepted = checkForCondition('HubAcceptedManagedCluster');
+    const clusterJoined = checkForCondition('ManagedClusterJoined');
+    const clusterAvailable = checkForCondition('ManagedClusterConditionAvailable');
+    if (_.get(cluster, 'metadata.deletionTimestamp')) {
+      status = 'detaching';
+    } else if (!clusterAccepted) {
+      status = 'notaccepted';
+    } else if (!clusterJoined) {
+      status = 'pendingimport';
+      if (csrs && csrs.length) {
+        status = !_.get(getLatest(csrs, 'metadata.creationTimestamp'), 'status.certificate')
+          ? 'needsapproval' : 'pending';
+      }
+    } else {
+      status = clusterAvailable ? 'ok' : 'offline';
+    }
+
+    // if ManagedCluster has not joined or is detaching, show ClusterDeployment status
+    // as long as it is not 'detached' (which is the ready state when there is no attached ManagedCluster,
+    // so this is the case is the cluster is being detached but not destroyed)
+    if ((status === 'detaching' || !clusterJoined) && (clusterDeploymentStatus && clusterDeploymentStatus !== 'detached')) {
+      return clusterDeploymentStatus;
+    }
+    return status;
+  }
+  return clusterDeploymentStatus;
+}
+
+function mapResources(resources, kind) {
+  const resultMap = new Map();
+  if (resources) {
+    resources.forEach((r) => {
+      if (r.metadata && (!r.kind || r.kind === kind)) {
+        const key = r.metadata.name;
+        resultMap.set(key, { metadata: r.metadata, raw: r });
+      }
+    });
+  }
+  return resultMap;
+}
+
+function mapResourceListByLabel(resourceList, label) {
+  return new Map(Object.entries(_.groupBy(resourceList, (i) => i.metadata.labels[label])));
+}
+
+function mapData({
+  managedClusters,
+  managedClusterInfos,
+  clusterDeployments,
+  certificateSigningRequestList,
+  uninstallJobList,
+  installJobList,
+}) {
+  const managedClusterMap = mapResources(managedClusters, 'ManagedCluster');
+  const clusterDeploymentMap = mapResources(clusterDeployments, 'ClusterDeployment');
+  const managedClusterInfoMap = mapResources(managedClusterInfos, 'ManagedClusterInfo');
+  const certificateSigningRequestListMap = mapResourceListByLabel(certificateSigningRequestList, CSR_LABEL);
+  const uninstallJobListMap = mapResourceListByLabel(uninstallJobList, CLUSTER_LABEL);
+  const installJobListMap = mapResourceListByLabel(installJobList, CLUSTER_LABEL);
+
+  const uniqueClusterNames = new Set([
+    ...managedClusterMap.keys(),
+    ...clusterDeploymentMap.keys(),
+  ]);
+
+  return {
+    managedClusterMap,
+    clusterDeploymentMap,
+    managedClusterInfoMap,
+    certificateSigningRequestListMap,
+    uninstallJobListMap,
+    installJobListMap,
+    uniqueClusterNames,
+  };
+}
+
+function getClusterResourcesFromMappedData({
+  managedClusterMap,
+  clusterDeploymentMap,
+  managedClusterInfoMap,
+  certificateSigningRequestListMap,
+  uninstallJobListMap,
+  installJobListMap,
+}, cluster) {
+  const managedCluster = managedClusterMap.get(cluster);
+  const managedClusterInfo = managedClusterInfoMap.get(cluster);
+  const clusterDeployment = clusterDeploymentMap.get(cluster);
+  const certificateSigningRequestList = certificateSigningRequestListMap.get(cluster);
+  const uninstallJobList = uninstallJobListMap.get(cluster);
+  const installJobList = installJobListMap.get(cluster);
+  return {
+    managedCluster,
+    managedClusterInfo,
+    clusterDeployment,
+    certificateSigningRequestList,
+    uninstallJobList,
+    installJobList,
+  };
+}
+
+function getBaseCluster(mappedData, cluster) {
+  const { managedCluster, managedClusterInfo, clusterDeployment } = getClusterResourcesFromMappedData(mappedData, cluster);
+
+  const metadata = _.get(managedCluster, 'metadata')
+  || _.pick(_.get(managedClusterInfo || clusterDeployment, 'metadata'), ['name', 'namespace']);
+  if (!metadata.namespace) {
+    metadata.namespace = _.get(managedClusterInfo || clusterDeployment, 'metadata.namespace') || metadata.name;
+  }
+  if (!metadata.labels) {
+    metadata.labels = _.get(managedClusterInfo, 'metadata.labels', '');
+  }
+
+  const clusterip = _.get(managedClusterInfo, 'raw.spec.masterEndpoint');
+
+  const consoleURL = _.get(managedClusterInfo, 'raw.status.consoleURL') || _.get(clusterDeployment, 'raw.status.webConsoleURL');
+
+  const apiURL = _.get(clusterDeployment, 'raw.status.apiURL');
+  const masterEndpoint = _.get(managedClusterInfo, 'raw.spec.masterEndpoint');
+  const serverAddress = apiURL || masterEndpoint;
+
+  return {
+    metadata,
+    clusterip,
+    consoleURL,
+    rawCluster: _.get(managedCluster, 'raw'),
+    rawStatus: _.get(managedClusterInfo, 'raw'),
+    serverAddress,
+  };
+}
+
+function findMatchedStatusForOverview(data) {
+  const mappedData = mapData(data);
+  const { uniqueClusterNames } = mappedData;
+  const resultMap = new Map();
+
+  uniqueClusterNames.forEach((c) => {
+    const cluster = getBaseCluster(mappedData, c);
+    const { managedCluster } = getClusterResourcesFromMappedData(mappedData, c);
+
+    const status = getStatus(_.get(managedCluster, 'raw'));
+    const capacity = _.get(managedCluster, 'raw.status.capacity');
+    const allocatable = _.get(managedCluster, 'raw.status.allocatable');
+
+    _.merge(cluster, {
+      status,
+      capacity,
+      allocatable,
+    });
+    resultMap.set(c, cluster);
+  });
+  return [...resultMap.values()];
+}
+
+export default class ClusterModel extends KubeModel {
+  constructor(args) {
+    super(args);
+    const { clusterNamespaces } = args;
+    this.clusterNamespaces = clusterNamespaces;
+  }
+
+  async getClusterResources() {
+    // Try cluster scope queries, falling back to per-cluster-namespace
+    const rbacFallbackQuery = (clusterQuery, namespaceQueryFunction) => (
+      this.kubeConnector.get(clusterQuery).then((allItems) => (allItems.items
+        ? allItems.items
+        : this.kubeConnector.getResources(
+          namespaceQueryFunction,
+          { namespaces: this.clusterNamespaces },
+        ))).catch((err) => {
+        logger.error(err);
+        throw err;
+      })
+    );
+
+    const [
+      managedClusters,
+      managedClusterInfos,
+      clusterDeployments,
+      certificateSigningRequestList,
+      uninstallJobList,
+      installJobList,
+    ] = await Promise.all([
+      rbacFallbackQuery(
+        '/apis/cluster.open-cluster-management.io/v1/managedclusters',
+        (ns) => `/apis/cluster.open-cluster-management.io/v1/managedclusters/${ns}`,
+      ),
+      rbacFallbackQuery(
+        '/apis/internal.open-cluster-management.io/v1beta1/managedclusterinfos',
+        (ns) => `/apis/internal.open-cluster-management.io/v1beta1/namespaces/${ns}/managedclusterinfos`,
+      ),
+      rbacFallbackQuery(
+        '/apis/hive.openshift.io/v1/clusterdeployments',
+        (ns) => `/apis/hive.openshift.io/v1/namespaces/${ns}/clusterdeployments`,
+      ),
+      this.kubeConnector.get(`/apis/certificates.k8s.io/v1beta1/certificatesigningrequests?${CSR_LABEL_SELECTOR_ALL}`)
+        .then((allItems) => (allItems.items
+          ? allItems.items
+          : [])).catch((err) => {
+          logger.error(err);
+          throw err;
+        }),
+      rbacFallbackQuery(
+        `/apis/batch/v1/jobs?${UNINSTALL_LABEL_SELECTOR_ALL}`,
+        (ns) => `/apis/batch/v1/namespaces/${ns}/jobs?${UNINSTALL_LABEL_SELECTOR(ns)}`,
+      ),
+      rbacFallbackQuery(
+        `/apis/batch/v1/jobs?${INSTALL_LABEL_SELECTOR_ALL}`,
+        (ns) => `/apis/batch/v1/namespaces/${ns}/jobs?${INSTALL_LABEL_SELECTOR(ns)}`,
+      ),
+    ]);
+
+    return {
+      managedClusters,
+      managedClusterInfos,
+      clusterDeployments,
+      certificateSigningRequestList,
+      uninstallJobList,
+      installJobList,
+    };
+  }
+
+  async getAllClusters(args = {}) {
+    const resources = await this.getClusterResources();
+    const results = findMatchedStatusForOverview(resources);
+    if (args.name) {
+      return results.filter((c) => c.metadata.name === args.name)[0];
+    }
+    return results;
+  }
+}

--- a/src/v2/models/compliance.js
+++ b/src/v2/models/compliance.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import _ from 'lodash';
+import logger from '../lib/logger';
+
+export default class ComplianceModel {
+  constructor({ kubeConnector }) {
+    if (!kubeConnector) {
+      throw new Error('kubeConnector is a required parameter');
+    }
+
+    this.kubeConnector = kubeConnector;
+  }
+
+  async getCompliances(name, namespace) {
+    let policies = [];
+
+    if (!name) {
+      // for getting policy list
+      const policyResponse = await this.kubeConnector.getResources((ns) => `/apis/policy.open-cluster-management.io/v1/namespaces/${ns}/policies`).catch((err) => {
+        logger.error(err);
+        throw err;
+      });
+      if (policyResponse.code || policyResponse.message) {
+        logger.error(`HCM ERROR ${policyResponse.code} - ${policyResponse.message}`);
+      }
+      policies = policyResponse || [];
+    } else {
+      // get single policy with a specific name - walkaround of no type field
+      const policyResponse = await this.kubeConnector.get(`/apis/policy.open-cluster-management.io/v1/namespaces/${namespace}/policies/${name}`).catch((err) => {
+        logger.error(err);
+        throw err;
+      });
+      if (policyResponse.code || policyResponse.message) {
+        logger.error(`HCM ERROR ${policyResponse.code} - ${policyResponse.message}`);
+      } else {
+        policies.push(policyResponse);
+      }
+    }
+    return policies.map((entry) => ({
+      ...entry,
+      raw: entry,
+      name: _.get(entry, 'metadata.name', ''),
+      namespace: _.get(entry, 'metadata.namespace', ''),
+      remediation: _.get(entry, 'spec.remediationAction', ''),
+      selfLink: _.get(entry, 'metadata.selfLink', ''),
+      apiVersion: _.get(entry, 'apiVersion', ''),
+    }));
+  }
+}

--- a/src/v2/models/generic.js
+++ b/src/v2/models/generic.js
@@ -1,0 +1,328 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import _ from 'lodash';
+import crypto from 'crypto';
+import KubeModel from './kube';
+import logger from '../lib/logger';
+
+const routePrefix = '/apis/action.open-cluster-management.io/v1beta1/namespaces';
+const clusterActionApiVersion = 'action.open-cluster-management.io/v1beta1';
+const authApiVersion = 'authorization.k8s.io/v1';
+const selfSubjectAccessReviewLink = '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews';
+
+function getGroupFromApiVersion(apiVersion) {
+  if (apiVersion.indexOf('/') >= 0) {
+    return { apiGroup: apiVersion.split('/')[0], version: apiVersion.split('/')[1] };
+  }
+  return { apiGroup: '', version: apiVersion };
+}
+
+function getApiGroupFromApiVersionOrPath(apiVersion, path, kind) {
+  if (apiVersion) {
+    return getGroupFromApiVersion(apiVersion);
+  }
+  // TODO - need to pass apigroup from backend to this function so we dont need this hack
+  let apiGroup = ''; // api group to differentiate between duplicate resources (ie. endpoints & subscriptions)
+  let version = '';
+  const pathData = path.split('/');
+  // eslint-disable-next-line
+  // When splitting the path, the item at pathData[3] is either the api version (if the resource has an apiGroup namespaced or not),
+  // resource kind (if the resource is non-namespaced AND doesn’t have an apiGroup) or namespaces (if the resource is namespaced AND doesn’t have an apiGroup).
+  // knowing this we grab the apiGroup if pathData[3] is not the kind or 'namespaces'
+  if (pathData[3] !== kind && pathData[3] !== 'namespaces') {
+    // eslint-disable-next-line prefer-destructuring
+    apiGroup = pathData[2];
+    // eslint-disable-next-line prefer-destructuring
+    version = pathData[3];
+  } else {
+    // eslint-disable-next-line prefer-destructuring
+    version = pathData[1];
+  }
+  return { apiGroup, version };
+}
+
+export default class GenericModel extends KubeModel {
+  async userAccess({
+    resource, kind, action, namespace = '', apiGroup = '*', name = '', version = '*',
+  }) {
+    let computedResource;
+    if (!resource) {
+      computedResource = (await this.getResourceInfo({
+        apiVersion: (apiGroup === '*' || apiGroup === '')
+          ? version
+          : `${apiGroup}/${version}`,
+        kind,
+      }))[1].name;
+    }
+    const body = {
+      apiVersion: authApiVersion,
+      kind: 'SelfSubjectAccessReview',
+      spec: {
+        resourceAttributes: {
+          verb: action,
+          resource: resource || computedResource,
+          namespace,
+          group: apiGroup,
+          name,
+          version,
+        },
+      },
+    };
+    const response = await this.kubeConnector.post(selfSubjectAccessReviewLink, body);
+    if (response.status === 'Failure' || response.code >= 400) {
+      throw new Error(`Get User Access Failed [${response.code}] - ${response.message}`);
+    }
+    return { ...response.status, ...response.spec.resourceAttributes };
+  }
+
+  async getLogs(containerName, podName, podNamespace, clusterName) {
+    if (clusterName === 'local-cluster') { // TODO: Use flag _hubClusterResource instead of cluster name
+      return this.kubeConnector.get(`/api/v1/namespaces/${podNamespace}/pods/${podName}/log?container=${containerName}&tailLines=1000`).catch((err) => {
+        logger.error(err);
+        throw err;
+      });
+    }
+    return this.kubeConnector.get(`/apis/proxy.open-cluster-management.io/v1beta1/namespaces/${clusterName
+    }/clusterstatuses/${clusterName}/log/${podNamespace}/${podName}/${containerName}?tailLines=1000`, { json: false }, true).catch((err) => {
+      logger.error(err);
+      throw err;
+    });
+  }
+
+  // Generic query to get local and remote resource data
+  // Remote resources are queried using ManagedClusterView
+  async getResource(args) {
+    const {
+      apiVersion,
+      selfLink,
+      cluster = '',
+      kind,
+      name,
+      namespace = '',
+      updateInterval,
+      deleteAfterUse = true,
+    } = args;
+    const path = selfLink || `${await this.getResourceEndPoint({ apiVersion, kind, metadata: { namespace } })}/${name}`;
+    if (cluster === 'local-cluster') {
+      return this.kubeConnector.get(path).catch((err) => {
+        logger.error(err);
+        throw err;
+      });
+    }
+
+    if (cluster !== 'local-cluster' && kind === 'secret') {
+      // We do not allow users to view secrets as this could allow lesser permissioned users to get around RBAC.
+      return [{
+        message: 'Viewing managed cluster secrets is not allowed for security reasons. To view this secret, you must access it from the specific managed cluster.',
+      }];
+    }
+
+    // Check if the ManagedClusterView already exists if not create it
+    const managedClusterViewName = crypto.createHash('sha1').update(`${cluster}-${name}-${kind}`).digest('hex').substr(0, 63);
+
+    const resourceResponse = await this.kubeConnector.get(
+      `/apis/view.open-cluster-management.io/v1beta1/namespaces/${cluster}/managedclusterviews/${managedClusterViewName}`,
+    ).catch((err) => {
+      logger.error(err);
+      throw err;
+    });
+    if (resourceResponse.status === 'Failure' || resourceResponse.code >= 400) {
+      const { apiGroup, version } = getApiGroupFromApiVersionOrPath(apiVersion, path, kind);
+      const response = await this.kubeConnector.managedClusterViewQuery(
+        cluster,
+        apiGroup,
+        version,
+        kind,
+        name,
+        namespace,
+        updateInterval,
+        deleteAfterUse,
+      ).catch((err) => {
+        logger.error(err);
+        throw err;
+      });
+
+      const resourceResult = _.get(response, 'status.result');
+      if (resourceResult) {
+        return resourceResult;
+      }
+
+      return [{ message: 'Unable to load resource data. Verify that the resource you are looking for exists, and check if the cluster that hosts the resource is online.' }];
+    }
+    return _.get(resourceResponse, 'status.result');
+  }
+
+  async updateResource(args) {
+    const {
+      body, cluster,
+    } = args;
+    const requestBody = { body };
+
+    const {
+      apiVersion, kind, metadata: { name, namespace },
+    } = body;
+    const path = `${await this.getResourceEndPoint({ apiVersion, kind, metadata: { namespace } })}/${name}`;
+
+    if (cluster === 'local-cluster') {
+      const localResponse = await this.kubeConnector.put(path, requestBody);
+      if (localResponse.message) {
+        throw new Error(`${localResponse.code} - ${localResponse.message}`);
+      }
+      return localResponse;
+    }
+    const { apiGroup, version } = getApiGroupFromApiVersionOrPath(apiVersion, path, kind);
+    // Else If updating resource on remote cluster use an Action Type Work
+    // Limit workName to 63 characters
+    let workName = `update-resource-${this.kubeConnector.uid()}`;
+    workName = workName.substring(0, 63);
+    const jsonBody = {
+      apiVersion: clusterActionApiVersion,
+      kind: 'ManagedClusterAction',
+      metadata: {
+        name: workName,
+        namespace: cluster,
+      },
+      spec: {
+        cluster: {
+          name: cluster,
+        },
+        type: 'Action',
+        scope: {
+          resourceType: apiGroup ? `${kind.toLowerCase()}.${version}.${apiGroup}` : `${kind.toLowerCase()}`,
+          namespace,
+        },
+        actionType: 'Update',
+        kube: {
+          resource: apiGroup ? `${kind.toLowerCase()}.${version}.${apiGroup}` : `${kind.toLowerCase()}`,
+          name,
+          namespace,
+          template: body,
+        },
+      },
+    };
+    const actionPath = `${routePrefix}/${cluster}/managedclusteractions`;
+    const response = await this.kubeConnector.post(actionPath, jsonBody);
+    if (response.code || response.message) {
+      logger.error(`OCM ERROR ${response.code} - ${response.message}`);
+      return [{
+        code: response.code,
+        message: response.message,
+      }];
+    }
+    const { cancel, promise: pollPromise } = this.kubeConnector.pollView(`${actionPath}/${workName}`);
+
+    try {
+      const result = await Promise.race([pollPromise, this.kubeConnector.timeout()]);
+      if (result) {
+        this.kubeConnector.delete(`${routePrefix}/${cluster}/managedclusteractions/${response.metadata.name}`)
+          .catch((e) => logger.error(`Error deleting work ${response.metadata.name}`, e.message));
+      }
+      const reason = _.get(result, 'status.conditions[0].reason');
+      if (reason && reason !== 'ActionDone') {
+        const message = _.get(result, 'status.conditions[0].message');
+        throw new Error(`Failed to Update ${name}. ${reason}. ${message}.`);
+      } else {
+        return _.get(result, 'status.result');
+      }
+    } catch (e) {
+      logger.error('Resource Action Error:', e.message);
+      cancel();
+      throw e;
+    }
+  }
+
+  async deleteResource(args) {
+    const {
+      apiVersion, selfLink, name, namespace, cluster, kind, childResources,
+    } = args;
+    if (childResources) {
+      const errors = this.deleteChildResource(childResources);
+      if (errors && errors.length > 0) {
+        throw new Error(`OCM ERROR: Unable to delete child resource(s) - ${JSON.stringify(errors)}`);
+      }
+    }
+
+    const path = selfLink || `${await this.getResourceEndPoint({ apiVersion, kind, metadata: { namespace } })}/${name}`;
+    // Local cluster case
+    if ((cluster === '' || cluster === 'local-cluster' || cluster === undefined)) {
+      const localResponse = await this.kubeConnector.delete(path, {});
+      if (localResponse.status === 'Failure' || localResponse.code >= 400) {
+        throw new Error(`Failed to delete the requested resource [${localResponse.code}] - ${localResponse.message}`);
+      }
+      return localResponse;
+    }
+
+    const { apiGroup, version } = getApiGroupFromApiVersionOrPath(apiVersion, path, kind);
+
+    // Else if deleting resource on remote cluster use Action Type Work
+    // Limit workName to 63 characters
+    let workName = `delete-resource-${this.kubeConnector.uid()}`;
+    workName = workName.substring(0, 63);
+    const jsonBody = {
+      apiVersion: clusterActionApiVersion,
+      kind: 'ManagedClusterAction',
+      metadata: {
+        name: workName,
+        namespace: cluster,
+      },
+      spec: {
+        cluster: {
+          name: cluster,
+        },
+        type: 'Action',
+        scope: {
+          resourceType: apiGroup ? `${kind.toLowerCase()}.${version}.${apiGroup}` : `${kind.toLowerCase()}`,
+          namespace,
+        },
+        actionType: 'Delete',
+        kube: {
+          resource: apiGroup ? `${kind.toLowerCase()}.${version}.${apiGroup}` : `${kind.toLowerCase()}`,
+          name,
+          namespace,
+        },
+      },
+    };
+
+    const apiPath = `${routePrefix}/${cluster}/managedclusteractions`;
+    const response = await this.kubeConnector.post(apiPath, jsonBody);
+    if (response.code || response.message) {
+      logger.error(`OCM ERROR ${response.code} - ${response.message}`);
+      return [{
+        code: response.code,
+        message: response.message,
+      }];
+    }
+    const managedClusterViewName = _.get(response, 'metadata.name');
+    const { cancel, promise: pollPromise } = this.kubeConnector.pollView(`${apiPath}/${managedClusterViewName}`);
+    try {
+      const result = await Promise.race([pollPromise, this.kubeConnector.timeout()]);
+      if (result) {
+        this.kubeConnector.delete(`${routePrefix}/${cluster}/managedclusteractions/${response.metadata.name}`)
+          .catch((e) => logger.error(`Error deleting work ${response.metadata.name}`, e.message));
+      }
+      const reason = _.get(result, 'status.conditions[0].reason');
+      if (reason && reason !== 'ActionDone') {
+        const message = _.get(result, 'status.conditions[0].message');
+        throw new Error(`Failed to Delete ${name}. ${reason}. ${message}.`);
+      } else {
+        return _.get(result, 'metadata.name');
+      }
+    } catch (e) {
+      logger.error('Resource Action Error:', e.message);
+      cancel();
+      throw e;
+    }
+  }
+
+  // Delete a ManagedClusterView resource
+  async deleteManagedClusterView(managedClusterNamespace, managedClusterViewName) {
+    await this.kubeConnector.deleteManagedClusterView(
+      managedClusterNamespace,
+      managedClusterViewName,
+    ).catch((err) => {
+      logger.error(err);
+      return null;
+    });
+  }
+}

--- a/src/v2/models/kube.js
+++ b/src/v2/models/kube.js
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import _ from 'lodash';
+import { isRequired } from '../lib/utils';
+import logger from '../lib/logger';
+
+// Abstract class for models that communicate with the kubernetes api
+export default class Kube {
+  constructor({ kubeConnector = isRequired('kubeConnector') }) {
+    this.kubeConnector = kubeConnector;
+  }
+
+  async getResourceInfo({ apiVersion, kind }) {
+    // dynamically get resource information from kubernetes API
+    const k8sPaths = await this.kubeConnector.getK8sPaths();
+    if (k8sPaths) {
+      const apiPath = k8sPaths.find((path) => path.match(`/[0-9a-zA-z]*/?${apiVersion}`));
+      if (apiPath) {
+        const k8sResourceList = await this.kubeConnector.get(`${apiPath}`).catch((err) => {
+          logger.error(err);
+          throw err;
+        });
+        const lowerKind = kind.toLowerCase();
+        const matchesKind = (value) => value.toLowerCase() === lowerKind;
+        const resourceType = k8sResourceList.resources.find((item) => (matchesKind(item.kind) || matchesKind(item.name) || matchesKind(item.singularName))
+          && item.name.indexOf('/') < 0);
+        return [apiPath, resourceType];
+      }
+    }
+    return [undefined, undefined];
+  }
+
+  async getResourceEndPoint({ apiVersion, kind, ...resource }) {
+    const [apiPath, resourceType] = await this.getResourceInfo({ apiVersion, kind });
+    if (apiPath) {
+      const namespace = _.get(resource, 'metadata.namespace');
+      const { name, namespaced } = resourceType || {};
+      if (!name || (namespaced && !namespace)) {
+        return null;
+      }
+      const namespaceSegments = namespaced ? `namespaces/${namespace}/` : '';
+      return `${apiPath}/${namespaceSegments}${name}`;
+    }
+    return undefined;
+  }
+}

--- a/src/v2/schema/__snapshots__/user-access.test.js.snap
+++ b/src/v2/schema/__snapshots__/user-access.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`User Access Resolver Correctly Resolves User Access Query 1`] = `
+Object {
+  "data": Object {
+    "userAccess": Object {
+      "allowed": true,
+      "reason": "RBAC: allowed by ClusterRoleBinding \\"oidc-admin-binding\\" of ClusterRole \\"cluster-admin\\" to User \\"admin\\"",
+      "resource": "selfsubjectrulesreviews",
+      "verb": "get",
+    },
+  },
+}
+`;

--- a/src/v2/schema/generic-resources.js
+++ b/src/v2/schema/generic-resources.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+import { gql } from 'apollo-server-express';
+
+export const typeDef = gql`
+  type logs {
+    containerName: String!
+    podName: String!
+    podNamespace: String!
+    clusterName: String!
+  }
+
+  type getResource {
+    apiVersion: String
+    kind: String
+    name: String
+    namespace: String
+    cluster: String
+    selfLink: String
+    updateInterval: Int
+    deleteAfterUse: Boolean
+  }
+
+  type updateResource {
+    selfLink: String
+    namespace: String
+    kind: String
+    name: String
+    body: JSON
+    cluster: String
+  }
+
+  type deleteResource {
+    selfLink: String
+    apiVersion: String
+    name: String
+    namespace: String
+    cluster: String
+    kind: String
+    childResources: JSON
+  }
+`;
+
+export const resolver = {
+  Query: {
+    getResource: (parent, args, { genericModel }) => genericModel.getResource(args),
+    logs: (parent, args, { genericModel }) => genericModel.getLogs(args.containerName, args.podName, args.podNamespace, args.clusterName),
+  },
+  Mutation: {
+    updateResource: (parent, args, { genericModel }) => genericModel.updateResource(args),
+    deleteResource: (root, args, { genericModel }) => genericModel.deleteResource(args),
+  },
+};

--- a/src/v2/schema/generic-resources.test.js
+++ b/src/v2/schema/generic-resources.test.js
@@ -1,0 +1,78 @@
+/** *****************************************************************************
+ * Licensed Materials - Property of IBM
+ * (c) Copyright IBM Corporation 2018. All Rights Reserved.
+ *
+ * Note to U.S. Government Users Restricted Rights:
+ * Use, duplication or disclosure restricted by GSA ADP Schedule
+ * Contract with IBM Corp.
+ ****************************************************************************** */
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import supertest from 'supertest';
+import server, { GRAPHQL_PATH } from '../index';
+
+describe.skip('Generic Resources', () => {
+  test('Correctly Resolves Get Resource Locally', () => new Promise((done) => {
+    supertest(server)
+      .post(GRAPHQL_PATH)
+      .send({
+        query: `
+        {
+          getResource(selfLink:"/api/v1/namespaces/kube-system/pods/monitoring-prometheus-nodeexporter-n6h9b", namespace:null, kind:null, name:null, cluster:"local-cluster")
+        }`,
+      })
+      .end((err, res) => {
+        expect(JSON.parse(res.text)).toMatchSnapshot();
+        done();
+      });
+  }));
+
+  test('Correctly Resolves Update Local Resource', () => new Promise((done) => {
+    supertest(server)
+      .post(GRAPHQL_PATH)
+      .send({
+        query: `
+        mutation {
+          updateResource(selfLink: "/api/v1/namespaces/klusterlet", namespace: "", kind: "namespace", name: "klusterlet", cluster: "local-cluster", body: {kind: "Namespace", apiVersion: "v1", metadata: {name: "klusterlet", selfLink: "/api/v1/namespaces/klusterlet", uid: "34ddc94d-70dc-11e9-865a-00000a15079c", resourceVersion: "2120711", creationTimestamp: "2019-05-07T15:24:29Z", labels: {icp: "system", test: "test"}}, spec: {finalizers: ["kubernetes"]}, status: {phase: "Active"}})
+        }
+        `,
+      })
+      .end((err, res) => {
+        expect(JSON.parse(res.text)).toMatchSnapshot();
+        done();
+      });
+  }));
+
+  test('Correctly Resolves Update Remote Resource', () => new Promise((done) => {
+    supertest(server)
+      .post(GRAPHQL_PATH)
+      .send({
+        query: `
+        mutation {
+          updateResource(selfLink: "/api/v1/namespaces/kube-system/secrets/platform-auth-service", namespace: "kube-system", kind: "Secret", name: "platform-auto-service", cluster: "layne-remote", body: {apiVersion: "v1", kind: "Secret", metadata: {creationTimestamp: "2019-04-16T01:40:57Z", name: "platform-auth-service", namespace: "kube-system", resourceVersion: "6278503", selfLink: "/api/v1/namespaces/kube-system/secret/platform-auth-service", uid: "ae97cf94-5fe8-11e9-bfe4-00000a150993"}, })
+        }
+        `,
+      })
+      .end((err, res) => {
+        expect(JSON.parse(res.text)).toMatchSnapshot();
+        done();
+      });
+  }));
+
+  test('Correctly Resolves Pod log query', () => new Promise((done) => {
+    supertest(server)
+      .post(GRAPHQL_PATH)
+      .send({
+        query: `
+        {
+          logs(containerName: "search-api", podName:"search-prod-28a0e-search-api-66cf776db5-7bzfh", podNamespace:"open-cluster-management", clusterName:"cluster1")
+        }
+      `,
+      })
+      .end((err, res) => {
+        expect(JSON.parse(res.text)).toMatchSnapshot();
+        done();
+      });
+  }));
+});

--- a/src/v2/schema/index.js
+++ b/src/v2/schema/index.js
@@ -16,16 +16,22 @@ import * as application from './application';
 import * as json from './json';
 import * as query from './query';
 import * as search from './search';
+import * as userAccess from './user-access';
 import * as userSearch from './user-search';
 import * as message from './message';
+import * as genericResources from './generic-resources';
+import * as overview from './overview';
 
 const modules = [
   application,
   json,
   query,
   search,
+  userAccess,
   userSearch,
   message,
+  genericResources,
+  overview,
 ];
 
 const mainDefs = [gql`
@@ -35,7 +41,7 @@ schema {
 }
 `];
 
-export const typeDefs = mainDefs.concat(modules.map((m) => m.typeDef));
+export const typeDefs = mainDefs.concat(modules.filter((m) => m.typeDef).map((m) => m.typeDef));
 export const resolvers = _.merge(...modules.map((m) => m.resolver));
 
 export default { typeDefs, resolvers };

--- a/src/v2/schema/overview.js
+++ b/src/v2/schema/overview.js
@@ -1,0 +1,108 @@
+/** *****************************************************************************
+ * Licensed Materials - Property of IBM
+ * (c) Copyright IBM Corporation 2018, 2019. All Rights Reserved.
+ *
+ * Note to U.S. Government Users Restricted Rights:
+ * Use, duplication or disclosure restricted by GSA ADP Schedule
+ * Contract with IBM Corp.
+ ****************************************************************************** */
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import { gql } from 'apollo-server-express';
+import _ from 'lodash';
+
+export const typeDef = gql`
+type Overview {
+  clusters: [ClusterOverview]
+  applications: [ApplicationOverview]
+  compliances: [ComplianceOverview]
+  timestamp: String
+}
+
+type ClusterOverview implements K8sObject {
+  metadata: Metadata
+  capacity: ClusterCapacity
+  allocatable: ClusterAllocatable
+  consoleURL: String
+  status: String
+}
+
+type ClusterCapacity {
+  cpu: String
+  memory: String
+}
+
+type ClusterAllocatable {
+  cpu: String
+  memory: String
+}
+
+type ApplicationOverview implements K8sObject {
+  metadata: Metadata
+  raw: JSON
+  selector: JSON
+}
+
+type ComplianceOverview implements K8sObject {
+  metadata: Metadata
+  raw: JSON
+}
+`;
+
+export const resolver = {
+  Query: {
+    overview: async (root, args, {
+      clusterModel, appModel, complianceModel,
+    }) => {
+      let clusters = await clusterModel.getAllClusters();
+      clusters = clusters.map(({
+        metadata, status, capacity, allocatable, consoleURL,
+      }) => {
+        const { name, namespace, labels = {} } = metadata;
+        ['vendor', 'cloud', 'region', 'environment'].forEach((key) => {
+          if (labels[key] === undefined) {
+            labels[key] = 'Other';
+          }
+        });
+        return {
+          metadata: {
+            name,
+            namespace,
+            labels,
+          },
+          consoleURL,
+          status,
+          capacity,
+          allocatable,
+        };
+      });
+
+      // number and what clusters
+      let applications = await appModel.getApplicationOverview();
+      applications = applications.map(({ metadata: { name } }) => ({
+        metadata: {
+          name,
+        },
+      }));
+
+      // policy compliances
+      let compliances = await complianceModel.getCompliances();
+      compliances = compliances.filter((c) => _.has(c, 'raw.status')).map(({ raw: { status: { status } } }) => ({
+        raw: {
+          status: {
+            status,
+          },
+        },
+      }));
+
+      // what time these values were fetched
+      // also forces apollo query to continially update the component even if nothing else changed
+      const timestamp = new Date().toString();
+
+      return {
+        clusters, applications, compliances, timestamp,
+      };
+    },
+  },
+};

--- a/src/v2/schema/overview.test.js
+++ b/src/v2/schema/overview.test.js
@@ -1,0 +1,66 @@
+/** *****************************************************************************
+ * Licensed Materials - Property of IBM
+ * (c) Copyright IBM Corporation 2018, 2019. All Rights Reserved.
+ *
+ * Note to U.S. Government Users Restricted Rights:
+ * Use, duplication or disclosure restricted by GSA ADP Schedule
+ * Contract with IBM Corp.
+ ****************************************************************************** */
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import supertest from 'supertest';
+import server, { GRAPHQL_PATH } from '../index';
+
+describe.skip('Overview Resolver', () => {
+  test('Correctly Resolves Overview Query', () => new Promise((done) => {
+    supertest(server)
+      .post(GRAPHQL_PATH)
+      .send({
+        query: `
+        {
+        overview {
+          clusters {
+            metadata {
+              name
+              namespace
+              labels
+              uid
+            }
+            capacity {
+              cpu
+              memory
+            }
+            allocatable {
+              cpu
+              memory
+            }
+            consoleURL
+            status
+          }
+          applications {
+            metadata {
+              name
+              namespace
+            }
+            raw
+            selector
+          }
+          compliances {
+            metadata {
+              name
+              namespace
+            }
+            raw
+          }
+          timestamp
+        }
+        }
+      `,
+      })
+      .end((err, res) => {
+        expect(JSON.parse(res.text)).toMatchSnapshot();
+        done();
+      });
+  }));
+});

--- a/src/v2/schema/query.js
+++ b/src/v2/schema/query.js
@@ -35,6 +35,18 @@ export const typeDef = gql`
 
     # Get saved search queries for the current user.
     savedSearches: [userSearch]
+
+    # Resolves if the current user is authorized to access a given resource.
+    userAccess(resource: String, kind: String, action: String!, namespace: String, apiGroup: String, name: String, version: String): JSON
+    
+    # Get any kubernetes resource from any managed cluster.
+    getResource(apiVersion: String, kind: String, name: String, namespace: String, cluster: String, selfLink: String, updateInterval: Int, deleteAfterUse: Boolean): JSON
+
+    # Retrieves logs for the given container.
+    logs(containerName: String!, podName: String!, podNamespace: String!, clusterName: String!): String
+
+    # Resolves the data needed to render the overview page.
+    overview(demoMode: Boolean): Overview
   }
 
   # Search API - Mutations
@@ -44,7 +56,39 @@ export const typeDef = gql`
 
     # Save a search query for the current user.
     saveSearch(resource: JSON): JSON
+
+    # Update any Kubernetes resources on both local and managed clusters.
+    updateResource(selfLink: String, namespace: String, kind: String, name: String, body: JSON, cluster: String): JSON
+  
+    # Delete any Kubernetes resource via selfLink
+    deleteResource(selfLink: String, apiVersion: String, name: String, namespace: String, cluster: String, kind: String, childResources: JSON): JSON  
+  }
+
+  # Common fields for all Kubernetes objects
+  interface K8sObject {
+    metadata: Metadata
+  }
+
+  # Common fields in all Kubernetes metadata objects.
+  type Metadata {
+    annotations: JSON
+    creationTimestamp: String
+    labels: JSON
+    name: String
+    namespace: String
+    resourceVersion: String
+    selfLink: String
+    status: String
+    uid: String
   }
 `;
 
-export const resolver = {};
+// export const resolver = {};
+export const resolver = {
+  K8sObject: {
+    // eslint-disable-next-line no-underscore-dangle
+    __resolveType() {
+      return null;
+    },
+  },
+};

--- a/src/v2/schema/user-access.js
+++ b/src/v2/schema/user-access.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import { gql } from 'apollo-server-express';
+
+export const typeDef = gql`
+type userAccess {
+  resource: String
+  action: String
+}
+`;
+
+export const resolver = {
+  Query: {
+    userAccess: (parent, args, { genericModel }) => genericModel.userAccess(args),
+  },
+};

--- a/src/v2/schema/user-access.test.js
+++ b/src/v2/schema/user-access.test.js
@@ -1,0 +1,31 @@
+/** *****************************************************************************
+ * Licensed Materials - Property of IBM
+ * (c) Copyright IBM Corporation 2019. All Rights Reserved.
+ *
+ * Note to U.S. Government Users Restricted Rights:
+ * Use, duplication or disclosure restricted by GSA ADP Schedule
+ * Contract with IBM Corp.
+ ****************************************************************************** */
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+import supertest from 'supertest';
+import server, { GRAPHQL_PATH } from '../index';
+
+describe('User Access Resolver', () => {
+  test('Correctly Resolves User Access Query', () => new Promise((done) => {
+    supertest(server)
+      .post(GRAPHQL_PATH)
+      .send({
+        query: `
+          {
+            userAccess(resource:"pods", action:"delete", namespace:"", apiGroup:"")
+          }
+      `,
+      })
+      .end((err, res) => {
+        expect(JSON.parse(res.text)).toMatchSnapshot();
+        done();
+      });
+  }));
+});


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Related Issue:**  open-cluster-management/backlog#9480

### Description of changes
Moved the following queries/mutations from console-api to search-api:
- getResource
- updateResource
- deleteResource
- userAccess
- getLogs
- getOverview

