### PR TITLE
testing if hsts is automatically enforced

### DIFF
--- a/src/v2/index.js
+++ b/src/v2/index.js
@@ -89,6 +89,7 @@ const requestLogger = isProd
   : morgan('dev');
 
 graphQLServer.use('*', helmet({
+  hsts:true,
   frameguard: false,
   noSniff: false,
   xssFilter: false,

--- a/src/v2/index.js
+++ b/src/v2/index.js
@@ -89,7 +89,7 @@ const requestLogger = isProd
   : morgan('dev');
 
 graphQLServer.use('*', helmet({
-  hsts: true,
+  // hsts: true,
   frameguard: false,
   noSniff: false,
   xssFilter: false,

--- a/src/v2/index.js
+++ b/src/v2/index.js
@@ -89,7 +89,7 @@ const requestLogger = isProd
   : morgan('dev');
 
 graphQLServer.use('*', helmet({
-  hsts:true,
+  hsts: true,
   frameguard: false,
   noSniff: false,
   xssFilter: false,


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#13645

### Description of changes
- temporarily disabling hsts to see if framework automatically enforces it to determine origin of duplicate hsts entry on Search response headers
