### PR TITLE
search-api needs to handle image property as a list

### DIFF
--- a/src/v2/connectors/redisGraph.js
+++ b/src/v2/connectors/redisGraph.js
@@ -23,7 +23,7 @@ import { isRequired } from '../lib/utils';
 import pollRbacCache, { getUserRbacFilter } from '../lib/rbacCaching';
 
 export function getPropertiesWithList() {
-  return ['label', 'role', 'port', 'container', 'category', 'rules', 'addon'];
+  return ['label', 'role', 'port', 'container', 'category', 'rules', 'addon', 'image'];
 }
 
 // Is there a more efficient way?


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Related Issue:**  open-cluster-management/backlog#14088

### Description of changes
- Image is saved as a list of images - search-api needs to correctly handle image as a list instead of a string

